### PR TITLE
feat(interface): Add type sharing feature between server & client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "@vitejs/plugin-react": "^3.0.0",
     "prettier": "^2.8.2",
     "typescript": "^4.9.3",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "zod": "^3.20.2"
   }
 }

--- a/client/src/store/socket.ts
+++ b/client/src/store/socket.ts
@@ -1,12 +1,12 @@
 import { atom } from "recoil";
-import type { ClientSocket } from "@/types";
+import type { BiseoSocket } from "@/types";
 
 export const tokenState = atom<string | null>({
   key: "token",
   default: null,
 });
 
-export const socketState = atom<ClientSocket | null>({
+export const socketState = atom<BiseoSocket | null>({
   key: "socket",
   default: null,
 });

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,4 +1,11 @@
 import type { Socket } from "socket.io-client";
+import type {
+  ClientToServerEvents,
+  ServerToClientEvents
+} from "@socket/types";
 
-/** Shared types from server side code will be configured here globally */
-export type ClientSocket = Socket;
+/** Shared socket from server side code are configured here globally */
+export type BiseoSocket = Socket<
+  ServerToClientEvents,
+  ClientToServerEvents
+>;

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -4,7 +4,8 @@
     "useDefineForClassFields": true,
     "baseUrl": "src",
     "paths": {
-      "@/*": ["*"]
+      "@/*": ["*"],
+      "@socket/*": ["../../socket/*"]
     },
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
@@ -20,6 +21,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"],
+  "include": ["src", "../socket"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -793,3 +793,8 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+zod@^3.20.2:
+  version "3.20.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.20.2.tgz#068606642c8f51b3333981f91c0a8ab37dfc2807"
+  integrity sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,10 +2,11 @@ import express from "express";
 import { createServer } from "http";
 import { Server } from "socket.io";
 import { adminAgendaListener } from "@/listener/admin.agenda";
+import type { BiseoServer } from "./types";
 
 const app = express();
 const httpServer = createServer(app);
-const io = new Server(httpServer, {
+const io: BiseoServer = new Server(httpServer, {
   cors: { origin: "*" },
 });
 const port = 3000;

--- a/server/src/listener/admin.agenda.ts
+++ b/server/src/listener/admin.agenda.ts
@@ -1,11 +1,11 @@
-import { type Server, type Socket } from "socket.io";
+import type { BiseoServer, BiseoSocket } from "@/types";
 import { Request } from "../../../socket/io";
 import { type Create } from "../../../socket/admin.agenda";
 import { createRequestSchema } from "@/model/agenda";
 import { agendaCreate } from "@/service/admin.agenda";
 import httpStatus from "http-status";
 
-export const adminAgendaListener = (io: Server, socket: Socket): void => {
+export const adminAgendaListener = (io: BiseoServer, socket: BiseoSocket): void => {
   socket.on(
     "admin/agenda/create",
     async (

--- a/server/src/model/chat/client.ts
+++ b/server/src/model/chat/client.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import type { ClientEvent } from "@socket/helpers";
+import { messageSchema } from "./common";
+
+// Send
+export const sendSchema = z.object({
+  message: z.string(),
+});
+type Send = z.infer<typeof sendSchema>;
+export const sendCallbackSchema = messageSchema;
+type SendCallback = z.infer<typeof sendCallbackSchema>;
+
+// Retrieve
+export const retrieveSchema = z.object({
+  lastChatId: z.number().nullable(),
+  limit: z.number(),
+});
+type Retrieve = z.infer<typeof retrieveSchema>;
+export const retrieveCallbackSchema = z.array(messageSchema);
+type RetrieveCallback = z.infer<typeof retrieveCallbackSchema>;
+
+export interface ClientToServerEvents {
+  send: ClientEvent<Send, SendCallback>;
+  retrieve: ClientEvent<Retrieve, RetrieveCallback>;
+}

--- a/server/src/model/chat/common.ts
+++ b/server/src/model/chat/common.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const messageSchema = z.object({
+	id: z.number(),
+	user: z.object({
+		id: z.number(),
+		nickname: z.string(),
+	}),
+	type: z.string(),
+	message: z.string(),
+	createdAt: z.string(),
+});
+
+

--- a/server/src/model/chat/index.ts
+++ b/server/src/model/chat/index.ts
@@ -1,0 +1,6 @@
+import type { Prefix } from "@socket/helpers";
+import type { ClientToServerEvents } from "./client";
+import type { ServerToClientEvents } from "./server";
+
+export type ChatClientToServerEvents = Prefix<"chat", ClientToServerEvents>;
+export type ChatServerToClientEvents = Prefix<"chat", ServerToClientEvents>;

--- a/server/src/model/chat/server.ts
+++ b/server/src/model/chat/server.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+import { messageSchema } from "./common";
+import { ServerEvent } from "@socket/helpers";
+
+type Received = z.infer<typeof messageSchema>;
+
+export interface ServerToClientEvents {
+  received: ServerEvent<Received>;
+}

--- a/server/src/model/index.ts
+++ b/server/src/model/index.ts
@@ -1,0 +1,4 @@
+export type {
+  ChatServerToClientEvents,
+  ChatClientToServerEvents,
+} from "./chat";

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,0 +1,17 @@
+import type { Server, Socket } from "socket.io";
+import type {
+  ClientToServerEvents,
+  ServerToClientEvents,
+} from "@socket/types";
+
+/** Strict server type based on model schemas */
+export type BiseoServer = Server<
+  ClientToServerEvents,
+  ServerToClientEvents
+>;
+
+export type BiseoSocket = Socket<
+  ClientToServerEvents,
+  ServerToClientEvents
+>;
+

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -5,7 +5,8 @@
     "module": "commonjs",
     "baseUrl": "src",
     "paths": {
-      "@/*": ["*"]
+      "@/*": ["*"],
+      "@socket/*": ["../../socket/*"],
     },
     "resolveJsonModule": true,
     "allowJs": true,

--- a/socket/helpers.ts
+++ b/socket/helpers.ts
@@ -1,0 +1,16 @@
+type CallbackResponse<T extends Record<string, any>> = {
+  ok: true;
+  data: T;
+} | {
+  ok: false;
+  message: string;
+}
+
+export type ClientEvent<I extends Record<string, any>, O extends Record<string, any>>
+  = (input: I, callback: (output: CallbackResponse<O>) => void) => void;
+
+export type ServerEvent<O extends Record<string, any>>
+  = (output: O) => void;
+
+export type Prefix<P extends string, E extends Record<string, any>> =
+  { [K in keyof E as K extends string ? `${P}/${K}` : never]: E[K] };

--- a/socket/types.ts
+++ b/socket/types.ts
@@ -1,0 +1,11 @@
+import type {
+  ChatClientToServerEvents,
+  ChatServerToClientEvents,
+} from "../server/src/model";
+
+export type ClientToServerEvents =
+  & ChatClientToServerEvents;
+
+export type ServerToClientEvents =
+  & ChatServerToClientEvents;
+


### PR DESCRIPTION
Support strict typing & intellisense throughout server & client sockets.
Can be used by adding `ServerToClientEvents` & `ClientToServerEvents` by a generic parameter when initializing a `Server` or a `Client` instance. Type `BiseoClient`, `BiseoServer`, and `BiseoSocket` is also available as aliases.