### PR TITLE
Introduce custom logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@
 **/.DS_Store
 
 # Logs
-*.log
+/logs

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,3 @@
 
 # File system
 **/.DS_Store
-
-# Logs
-/logs

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,2 +1,5 @@
 /node_modules
 /dist
+
+# Logs
+/logs

--- a/server/nodemon.json
+++ b/server/nodemon.json
@@ -2,5 +2,8 @@
   "ignore": ["node_modules/**/node_modules"],
   "watch": ["src/", ".env"],
   "ext": "js,ts,json",
-  "exec": "ts-node -r tsconfig-paths/register --transpile-only src/index.ts"
+  "exec": "ts-node -r tsconfig-paths/register --transpile-only src/index.ts",
+  "env": {
+    "NODE_ENV": "development"
+  }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,8 @@
     "jsonwebtoken": "^9.0.0",
     "ldapts": "^4.2.6",
     "socket.io": "^4.5.4",
+    "winston": "^3.10.0",
+    "winston-daily-rotate-file": "^4.7.1",
     "zod": "^3.20.2"
   },
   "devDependencies": {

--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 const schema = z.object({
+  NODE_ENV: z.enum(["development", "production", "test"]),
   SERVER_PORT: z.coerce.number(),
   SECRET_KEY: z.string(),
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,9 +3,9 @@ import { createServer } from "http";
 import { Server } from "socket.io";
 
 import type { BiseoServer } from "@/types/socket";
-import { authRouter } from "./auth/router";
-import { env } from "./env";
-import { logger } from "./utils/logger";
+import { authRouter } from "@/auth/router";
+import { env } from "@/env";
+import { logger } from "@/utils/logger";
 
 import { auth } from "@/auth/socket";
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import { Server } from "socket.io";
 import type { BiseoServer } from "@/types/socket";
 import { authRouter } from "./auth/router";
 import { env } from "./env";
+import { logger } from "./utils/logger";
 
 import { auth } from "@/auth/socket";
 
@@ -29,10 +30,10 @@ app.use("/api/auth", authRouter);
 
 io.use(auth);
 
-io.on("connection", (socket) => {
+io.on("connection", socket => {
   adminAgendaRouter.register(io, socket);
   chatRouter.register(io, socket);
 });
 
 httpServer.listen(port);
-console.log(`Server listening on port ${port}`);
+logger.info(`Server listening on port ${port}`);

--- a/server/src/lib/error.ts
+++ b/server/src/lib/error.ts
@@ -1,4 +1,5 @@
 import { Error as ErrorResponse } from "biseo-interface/helpers";
+import { logger } from "@/utils/logger";
 
 export class BiseoError extends Error {
   constructor(message: string) {
@@ -10,7 +11,12 @@ export class BiseoError extends Error {
   }
 }
 
-export const errorHandler = (callback: (e: ErrorResponse) => void) => (err: unknown) => {
-  if (err instanceof BiseoError) return callback(err.serialize());
-  return callback(new BiseoError("internal server error").serialize());
-};
+export const errorHandler =
+  (callback: (e: ErrorResponse) => void) => (err: unknown) => {
+    if (err instanceof BiseoError) {
+      logger.info(err.message);
+      return callback(err.serialize());
+    }
+    logger.error(err);
+    return callback(new BiseoError("internal server error").serialize());
+  };

--- a/server/src/service/admin.agenda.ts
+++ b/server/src/service/admin.agenda.ts
@@ -3,7 +3,7 @@ import * as schema from "biseo-interface/admin/agenda";
 import { prisma } from "@/db/prisma";
 import { AgendaStatus } from "biseo-interface/agenda";
 
-import { logger } from "../utils/logger";
+import { logger } from "@/utils/logger";
 
 export const agendaCreate = async ({
   title,

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -2,7 +2,7 @@ import { createLogger, format, transports } from "winston";
 import dailyRotateFileTransport from "winston-daily-rotate-file";
 import path from "path";
 
-import { env } from "../env";
+import { env } from "@/env";
 
 // logger에서 사용할 포맷들을 정의합니다.
 const baseFormat = format.combine(

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -36,6 +36,15 @@ const datePattern = "YYYY-MM-DD-HH";
 // 로그 파일당 최대 크기(=5MB).
 const maxSize = 5 * 1024 * 1024;
 
+/**
+ * console.log()와 console.error() 대신 사용되는 winston Logger 객체입니다.
+ *
+ * - "production" 환경: 모든 로그는 파일 시스템에 저장되고, 오류 메시지는 콘솔로도 출력됩니다.
+ * - "development" & "test" 환경: 모든 로그는 콘솔에 출력됩니다.
+ *
+ * @method info(message: string, callback: winston.LogCallback) - 일반적인 정보(API 접근 등) 기록을 위해 사용합니다.
+ * @method error(message: string, callback: winston.LogCallback)  - 오류 메시지를 기록하기 위해 사용합니다.
+ */
 const logger =
   env.NODE_ENV === "production"
     ? // "production" 환경에서 사용되는 Logger 객체
@@ -44,28 +53,32 @@ const logger =
         format: uncolorizedFormat,
         defaultMeta: { service: "biseo" },
         transports: [
-          // 전체 로그("info", "warn", "error")를 저장합니다.
+          // 전체 로그("info", "warn", "error")를 파일로 출력합니다.
           new dailyRotateFileTransport({
             level: "info",
             filename: path.resolve("logs/%DATE%-combined.log"),
             datePattern,
             maxSize,
           }),
-          // 예외 처리로 핸들링 된 오류 로그("error")를 저장합니다.
+          // 예외 처리로 핸들링 된 오류 로그("error")를 파일과 콘솔에 출력합니다.
           new dailyRotateFileTransport({
             level: "error",
             filename: path.resolve("logs/%DATE%-error.log"),
             datePattern,
             maxSize,
           }),
+          new transports.Console({
+            level: "error",
+          }),
         ],
         exceptionHandlers: [
-          // 예외 처리가 되지 않은 오류 로그("error")를 저장합니다.
+          // 예외 처리가 되지 않은 오류 로그("error")를 파일과 콘솔에 출력합니다.
           new dailyRotateFileTransport({
             filename: path.resolve("logs/%DATE%-unhandled.log"),
             datePattern,
             maxSize,
           }),
+          new transports.Console(),
         ],
       })
     : // "development", "test" 환경에서 사용되는 Logger 객체
@@ -77,11 +90,4 @@ const logger =
         exceptionHandlers: [new transports.Console()],
       });
 
-/**
- * console.log()와 console.error() 대신 사용되는 winston Logger 객체입니다.
- * production 환경에서는 파일 시스템에 로그가 저장되고, development와 test 환경에서는 콘솔에 로그가 출력됩니다.
- *
- * @method info(message: string, callback: winston.LogCallback) - 일반적인 정보(API 접근 등) 기록을 위해 사용합니다.
- * @method error(message: string, callback: winston.LogCallback)  - 오류 메시지를 기록하기 위해 사용합니다.
- */
 export { logger };

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -1,0 +1,74 @@
+import { createLogger, format, transports } from "winston";
+import dailyRotateFileTransport from "winston-daily-rotate-file";
+import path from "path";
+
+import { env } from "../env";
+
+// logger에서 사용할 포맷들을 정의합니다.
+const baseFormat = format.combine(
+  format.timestamp({ format: "YYYY-MM-DD HH:mm:ss(UTCZ)" }),
+  format.errors({ stack: true }),
+  format.splat(),
+  format.json(),
+);
+const finalFormat = format.printf(({ level, message, timestamp, stack }) => {
+  return `${timestamp} [${level}]: ${message} ${
+    level === "error" && stack !== undefined ? stack : ""
+  }`;
+});
+
+// 콘솔 출력 시 사용될 포맷. 색상이 표시됩니다.
+const consoleFormat = format.combine(
+  baseFormat,
+  format.colorize({ all: true }),
+  finalFormat,
+);
+
+// 파일 출력 시 사용될 포맷. 색 관련 특수문자가 파일에 쓰여지는 것을 방지하기 위해 색상이 표시되지 않습니다.
+const fileFormat = format.combine(baseFormat, format.uncolorize(), finalFormat);
+const datePattern = "YYYY-MM-DD-HH"; // 로그 파일명에 포함되는 시각
+const maxSize = 5242880; // 로그 파일당 최대 크기 (=5MB)
+
+/**
+ * console.log()와 console.error() 대신 사용되는 winston Logger 객체입니다.
+ *
+ * 전체 로그는 "logs/YYYY-MM-DD-HH.combined.log" 파일에,
+ * 예외 처리로 핸들링 된 오류 로그는 "logs/YYYY-MM-DD-HH.error.log" 파일에,
+ * 예외 처리가 되지 않은 오류는 "logs/YYYY-MM-DD-HH.unhandled.log"에 저장됩니다.
+ * @method info(message: string, callback: winston.LogCallback) - 일반적인 정보(API 접근 등) 기록을 위해 사용합니다.
+ * @method error(message: string, callback: winston.LogCallback)  - 오류 메시지를 기록하기 위해 사용합니다.
+ */
+const logger = createLogger({
+  level: "info", // "info"와 같은 중요도이거나 더 중요한 레벨의 로그들만 로깅합니다("info", "warn", "error").
+  format: fileFormat,
+  defaultMeta: { service: "biseo" },
+  transports: [
+    new dailyRotateFileTransport({
+      level: "info", // "info", "warn", "error" 로그를 저장합니다.
+      filename: path.resolve("../logs/%DATE%-combined.log"),
+      datePattern,
+      maxSize,
+    }),
+    new dailyRotateFileTransport({
+      level: "error", // "error" 로그를 저장합니다.
+      filename: path.resolve("../logs/%DATE%-error.log"),
+      datePattern,
+      maxSize,
+    }),
+    new transports.Console({
+      // production, test 환경에는 화려한 콘솔이 없을 가능성이 높으므로 색상 없이 출력합니다.
+      format: env.NODE_ENV === "development" ? consoleFormat : fileFormat,
+    }),
+  ],
+  exceptionHandlers: [
+    // 핸들링되지 않은 예외들은 별도의 파일로 저장됩니다. 콘솔로도 출력됩니다.
+    new dailyRotateFileTransport({
+      filename: path.resolve("../logs/%DATE%-unhandled.log"),
+      datePattern,
+      maxSize,
+    }),
+    new transports.Console(),
+  ],
+});
+
+export { logger };

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -31,14 +31,14 @@ const colorizedFormat = format.combine(
   finalFormat,
 );
 
-// 로그 파일명에 포함되는 시각 포맷을 정의합니다.
+// 로그 파일명에 포함되는 시각
 const datePattern = "YYYY-MM-DD-HH";
-// 로그 파일당 최대 크기를 정의합니다(=5MB).
-const maxSize = 5242880;
+// 로그 파일당 최대 크기(=5MB).
+const maxSize = 5 * 1024 * 1024;
 
 const logger =
   env.NODE_ENV === "production"
-    ? // "production" 환경에서 사용되는 winston Logger 객체를 생성합니다.
+    ? // "production" 환경에서 사용되는 Logger 객체
       createLogger({
         level: "info",
         format: uncolorizedFormat,
@@ -68,7 +68,7 @@ const logger =
           }),
         ],
       })
-    : // "development", "test" 환경에서 사용되는 winston Logger 객체입니다.
+    : // "development", "test" 환경에서 사용되는 Logger 객체
       createLogger({
         level: "info",
         format: colorizedFormat,

--- a/yarn.lock
+++ b/yarn.lock
@@ -395,6 +395,11 @@
     "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@commitlint/cli@^17.4.2":
   version "17.6.1"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-17.6.1.tgz#571a1272a656cd316f4b601cbb0fcb2ef50bfc7a"
@@ -562,6 +567,15 @@
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
+
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.3.tgz#7f7e97ee9a725dffc7808d93668cc984e1dc477a"
+  integrity sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
 
 "@emotion/babel-plugin@^11.11.0":
   version "11.11.0"
@@ -1195,6 +1209,11 @@
     "@types/mime" "*"
     "@types/node" "*"
 
+"@types/triple-beam@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.2.tgz#38ecb64f01aa0d02b7c8f4222d7c38af6316fef8"
+  integrity sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==
+
 "@types/uuid@>=9":
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.2.tgz#ede1d1b1e451548d44919dc226253e32a6952c4b"
@@ -1342,6 +1361,11 @@ asn1@~0.2.6:
   integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
   dependencies:
     safer-buffer "~2.1.0"
+
+async@^3.2.3:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1591,7 +1615,7 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -1610,10 +1634,34 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.6.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
+
+colorspace@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
+  integrity sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==
+  dependencies:
+    color "^3.1.3"
+    text-hex "1.0.x"
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -1887,6 +1935,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -2088,12 +2141,24 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fecha@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
+  integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
+
 figures@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
+
+file-stream-rotator@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz#007019e735b262bb6c6f0197e58e5c87cb96cec3"
+  integrity sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==
+  dependencies:
+    moment "^2.29.1"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -2140,6 +2205,11 @@ flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 follow-redirects@^1.15.0:
   version "1.15.2"
@@ -2412,6 +2482,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
@@ -2585,6 +2660,11 @@ kind-of@^6.0.3:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 ldapts@^4.2.6:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/ldapts/-/ldapts-4.2.6.tgz#608727b754367fb399fd3a97a6a7bcea208f580e"
@@ -2676,6 +2756,18 @@ lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+logform@^2.3.2, logform@^2.4.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.5.1.tgz#44c77c34becd71b3a42a3970c77929e52c6ed48b"
+  integrity sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    "@types/triple-beam" "^1.3.2"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    safe-stable-stringify "^2.3.1"
+    triple-beam "^1.3.0"
 
 loose-envify@^1.1.0:
   version "1.4.0"
@@ -2824,6 +2916,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+moment@^2.29.1:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 ms@2.0.0:
   version "2.0.0"
@@ -2986,6 +3083,11 @@ object-assign@^4:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
+object-hash@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
 object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
@@ -3004,6 +3106,13 @@ once@^1.3.0, once@^1.4.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
 
 onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
@@ -3261,7 +3370,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stream@^3.4.0:
+readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -3373,6 +3482,11 @@ safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-stable-stringify@^2.3.1:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
+  integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
 
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@~2.1.0:
   version "2.1.2"
@@ -3494,6 +3608,13 @@ signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
+
 simple-update-notifier@^1.0.7:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz#67694c121de354af592b347cdba798463ed49c82"
@@ -3585,6 +3706,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
 
 statuses@2.0.1:
   version "2.0.1"
@@ -3690,6 +3816,11 @@ text-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
   integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 through2@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/through2/-/through2-4.0.2.tgz#a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764"
@@ -3737,6 +3868,11 @@ trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+
+triple-beam@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.4.1.tgz#6fde70271dc6e5d73ca0c3b24e2d92afb7441984"
+  integrity sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==
 
 ts-node@^10.8.1, ts-node@^10.9.1:
   version "10.9.1"
@@ -3899,6 +4035,42 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+winston-daily-rotate-file@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/winston-daily-rotate-file/-/winston-daily-rotate-file-4.7.1.tgz#f60a643af87f8867f23170d8cd87dbe3603a625f"
+  integrity sha512-7LGPiYGBPNyGHLn9z33i96zx/bd71pjBn9tqQzO3I4Tayv94WPmBNwKC7CO1wPHdP9uvu+Md/1nr6VSH9h0iaA==
+  dependencies:
+    file-stream-rotator "^0.6.1"
+    object-hash "^2.0.1"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
+
+winston-transport@^4.4.0, winston-transport@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.5.0.tgz#6e7b0dd04d393171ed5e4e4905db265f7ab384fa"
+  integrity sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==
+  dependencies:
+    logform "^2.3.2"
+    readable-stream "^3.6.0"
+    triple-beam "^1.3.0"
+
+winston@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.10.0.tgz#d033cb7bd3ced026fed13bf9d92c55b903116803"
+  integrity sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.4.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.5.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->
https://github.com/winstonjs/winston 을 사용해 커스텀 로거를 추가합니다.
https://github.com/sparcs-kaist/taxi-back 에서 싱싱하게 수입해 왔습니다. 아니, 조금 수정을 가해서 택시 로거의 상위호환이예요 😄 

제가 도입하려는 logger에는 두 가지 특징이 있습니다.
1. 로그 레벨: 두 가지 로그 레벨을 사용합니다.
	a. "info" : 일반적인 정보(API 접근 등) 기록을 위해 사용합니다.
	b. "error" : 오류 메시지를 기록하기 위해 사용합니다.

2. 로그 출력 위치: production 여부에 따라 로그 출력 위치가 달라집니다.
	a. "production" : 모든 로그는 파일 시스템에 저장됩니다. 오류 메시지는 콘솔로도 출력됩니다.
	b. "development" 또는 "test" : 모든 로그는 콘솔에 출력됩니다.

예제로 현재 사용되고 있는 서비스 로직들에서 `console.log`와 `console.error` 함수들을 각각 `logger.info`와 `logger.error`로 교체했습니다.

# Images or Screenshots
- 콘솔에 로그 레벨, 타임스탬프와 함께 로그가 출력됩니다.
> <img width="606" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/46402016/7bf0dcc4-1374-439d-90d5-583842827041">

- 파일시스템에 로그 레벨, 타임스탬프와 함께 로그가 저장됩니다.
> <img width="540" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/46402016/683af07c-4a7e-4b09-8edc-5ddac4797d0f">


# Further Work

- API 접근 기록 및 응답 시간 로그 추가: 응답 시간을 측정하기 위해 express.js에서 공식적으로 제공하는 https://github.com/expressjs/response-time 모듈을 사용할 수 있습니다.
