### PR TITLE
fix(type): fix agenda status type

### DIFF
--- a/interface/agenda/common.ts
+++ b/interface/agenda/common.ts
@@ -20,13 +20,6 @@ export const ChoiceWithResult = Choice.extend({
 export type ChoiceWithResult = z.infer<typeof ChoiceWithResult>;
 
 /**
- * AgendaStatus
- * some description about agenda status type goes here
- */
-export const AgendaStatus = z.enum(["preparing", "ongoing", "terminated"]);
-export type AgendaStatus = z.infer<typeof AgendaStatus>;
-
-/**
  * AgendaBase
  * some description about agenda base schema goes here
  */
@@ -35,7 +28,7 @@ export const AgendaBase = z.object({
   title: z.string(),
   content: z.string(),
   resolution: z.string(),
-  status: AgendaStatus,
+  status: z.never(), // Must be overridden
   voters: z.object({
     voted: z.number(),
     total: z.number(),
@@ -48,7 +41,7 @@ export type AgendaBase = z.infer<typeof AgendaBase>;
  * some description about preparing agenda schema goes here
  */
 export const PreparingAgenda = AgendaBase.extend({
-  status: z.enum(["preparing"]),
+  status: z.literal("preparing"),
   user: z.object({
     votable: z.boolean(),
   }),
@@ -60,7 +53,7 @@ export type PreparingAgenda = z.infer<typeof PreparingAgenda>;
  * some description about ongoing agenda schema goes here
  */
 export const OngoingAgenda = AgendaBase.extend({
-  status: z.enum(["ongoing"]),
+  status: z.literal("ongoing"),
   user: z.object({
     votable: z.boolean(),
     voted: z.number().nullable(), // choiceId | null
@@ -74,7 +67,7 @@ export type OngoingAgenda = z.infer<typeof OngoingAgenda>;
  * some description about terminated agenda schema goes here
  */
 export const TerminatedAgenda = AgendaBase.extend({
-  status: z.enum(["terminated"]),
+  status: z.literal("terminated"),
   user: z.object({
     votable: z.boolean(),
     voted: z.number().nullable(), // choiceId | null
@@ -93,3 +86,9 @@ export const Agenda = z.union([
   TerminatedAgenda,
 ]);
 export type Agenda = z.infer<typeof Agenda>;
+
+/**
+ * AgendaStatus
+ * some description about agenda status type goes here
+ */
+export type AgendaStatus = Agenda["status"];


### PR DESCRIPTION
Fixes #41 

typescript에 discriminated union으로 취급되어 type narrowing이 일어나게 하기 위해서 타입 수정했습니다.
- `z.enum(["ongoing"])` -> `z.literal("ongoing")`
- `AgendaStatus` 타입 변경

기존 코드에 미치는 영향은 없습니다.


```typescript
// Agenda type
const agenda = { ... } as Agenda;

if (agenda.status === "ongoing") {
    agenda // <- inferred as TerminatedAgenda
}
```