### PR TITLE
fix(chat): setValue to null when sending by button

### DIFF
--- a/client/src/components/molecules/ChatInput.tsx
+++ b/client/src/components/molecules/ChatInput.tsx
@@ -12,7 +12,10 @@ interface Props {
 export const ChatInput: React.FC<Props> = ({ send }) => {
   const { input, setValue } = useInput();
 
-  const sendCurrent = useCallback(() => send(input.value), [input.value]);
+  const sendCurrent = useCallback(() => {
+    send(input.value);
+    setValue("");
+  }, [input.value]);
 
   return (
     <Box w="fill" pad={10} bg="white100">
@@ -22,7 +25,6 @@ export const ChatInput: React.FC<Props> = ({ send }) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
               sendCurrent();
-              setValue("");
             }
           }}
           {...input}


### PR DESCRIPTION
resolve #79 

chat에서 버튼을 눌러 전송하는 경우 입력했던 메세지가 그대로 남아있는 이슈