### PR TITLE
fix(ongoing): progress bar up to 1 decimal place

### DIFF
--- a/client/src/components/molecules/ParticipantBar.tsx
+++ b/client/src/components/molecules/ParticipantBar.tsx
@@ -52,7 +52,7 @@ export const ParticipantBar: React.FC<Props> = ({
         padVertical={6}
       >
         <Text color="black" variant="option1">
-          {total ? (participant * 100) / total : 0}%
+          {total ? ((participant * 100) / total).toFixed(1) : 0}%
         </Text>
         <Text color="black" variant="option1">
           {participant}/{total}


### PR DESCRIPTION
resolve #255 
우선 소수점 아래 1 자리까지 표시되도록 만들었어요
<img width="521" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/114305937/b2630210-20fe-496e-9549-863a4e46d581">
