### PR TITLE
fix: selected header item on modal open

### DIFF
--- a/client/src/components/organisms/Header.tsx
+++ b/client/src/components/organisms/Header.tsx
@@ -47,7 +47,11 @@ export const Header: React.FC = () => {
               key={index}
               name={item.name}
               path={item.path}
-              selected={window.location.pathname === "/" + item.path}
+              selected={
+                item.path === ""
+                  ? window.location.pathname === "/" + item.path
+                  : window.location.pathname.startsWith("/" + item.path)
+              }
             />
           ))
         ) : (


### PR DESCRIPTION
모달을 열어도 헤더 item select ui가 잘 작동해요
<img width="825" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/33417582/377479e3-4cae-4630-ab02-2d6e4042c17d">
Resolves #263 