### PR TITLE
[FEAT] Docker Compose에서 client, db 네트워크 분리

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - ./client:/usr/src/app
     depends_on:
       - server
+    networks:
+      - frontend
   server:
     container_name: biseo-server
     restart: always
@@ -29,6 +31,9 @@ services:
       dockerfile: .docker/server.Dockerfile
     depends_on:
       - db
+    networks:
+      - frontend
+      - backend
   db:
     container_name: biseo-db
     restart: always
@@ -39,7 +44,13 @@ services:
     volumes:
       - biseo-data:/var/lib/mysql
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    networks:
+      - backend
 
 volumes:
   biseo-data:
     external: true
+
+networks:
+  frontend:
+  backend:


### PR DESCRIPTION
It resolves #323 
Docker Compose에서 client(nginx 컨테이너)와 DB를 다른 네트워크로 분리하였습니다.
개발용 서버([biseo.dev.sparcs.org](biseo.dev.sparcs.org))에 배포하여 테스트 완료했습니다.

### Screenshots
[기존]
client와 server, db가 같은 네트워크로 연결되어 있습니다.
<img width="493" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/46402016/aa51409d-5def-420f-864e-ff401ddb58f8">

[작업 후]
server와 db가 같은 네트워크에 연결되어 있습니다 (`frontend` 도커 네트워크)
<img width="481" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/46402016/1d1ddc98-846c-4741-9bea-2b1ce8a2bae3">

client와 server가 같은 네트워크에 연결되어 있습니다 (`backend 도커 네트워크). client와 db는 직접적으로 같은 네트워크에 있지 않기 때문에, client에서 db에 접근할 수 없습니다.
<img width="484" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/46402016/2a559e61-73e4-417f-880d-70fd18f86efb">
