### PR TITLE
Enter로 입력하기, onKeyPress 대체하기

### DIFF
--- a/client/src/components/molecules/ChatInput.tsx
+++ b/client/src/components/molecules/ChatInput.tsx
@@ -37,8 +37,12 @@ export const ChatInput: React.FC<Props> = ({ send }) => {
     <Box w="fill" pad={10} bg="white100">
       <InputForm>
         <TextAreaAutosize
-          onKeyPress={e => {
-            if (e.key === "Enter" && !e.shiftKey) {
+          onKeyDown={e => {
+            if (
+              e.key === "Enter" &&
+              !e.shiftKey &&
+              !e.nativeEvent.isComposing
+            ) {
               e.preventDefault();
               sendCurrent();
             }

--- a/client/src/components/molecules/ModalInnerTextBox.tsx
+++ b/client/src/components/molecules/ModalInnerTextBox.tsx
@@ -193,8 +193,8 @@ const TextButton: React.FC<SubmitProps> = ({
       placeholder={children?.toString()}
       onChange={onClick}
       style={{ outline: "none" }}
-      onKeyPress={e => {
-        if (e.key === "Enter" && !e.shiftKey) {
+      onKeyDown={e => {
+        if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
           e.preventDefault();
           onSubmit();
         }

--- a/client/src/components/molecules/ModalInnerTextBox.tsx
+++ b/client/src/components/molecules/ModalInnerTextBox.tsx
@@ -193,6 +193,12 @@ const TextButton: React.FC<SubmitProps> = ({
       placeholder={children?.toString()}
       onChange={onClick}
       style={{ outline: "none" }}
+      onKeyPress={e => {
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          onSubmit();
+        }
+      }}
     />
     <Button w={20} h={20} onClick={onSubmit}>
       <Text color="blue600" variant="boldtitle2">


### PR DESCRIPTION
1. Resolve #152 by a7b5c0e328037871b3eb81f75b1239d8e6046cd9

ModalInnerTextBox와 비슷한 역할을 하던 ChatInput을 참고하여 만들었습니다.

2. Resolve #195 by cf69bf10b6286fad7ef06cbfff4fe274376bd8b5

ModalInnerTextBox와 ChatInput에 사용된 onKeyPress를 onKeyDown으로 대체하였습니다.
컴퓨터에서 한글을 입력하다보면 아랫쪽에 밑줄이 뜨는 것을 확인할 수 있습니다.
이는 한글이 조합 중이라는 의미로 한 문자를 완성하기 위해 입력이 이어질 수 있음을 의미합니다.
KeyboardEvent에서 현 상황이 조합 중인지를 확인하는 방법이 isComposing입니다.

이유는 모르겠으나 한글 입력 과정에서 KeyboardEvent를 받아오면 isComposing이 true인 것과 false인 것이 하나씩 생성되는데 true인 것이 마지막 글자만 잘린 상태로 오류를 야기합니다.
제 지식 내에서 최대한 다양한 상황을 시도해보았으나, **OS에 따라 문제가 일어날 수도 있다고 하니 Windows 사용하시는 분들이 직접 돌려보시면 좋겠습니다.**

[주 참고자료 - 현 이슈와 비슷한 상황을 서술한 블로그](https://velog.io/@corinthionia/JS-keydown%EC%97%90%EC%84%9C-%ED%95%9C%EA%B8%80-%EC%9E%85%EB%A0%A5-%EC%8B%9C-%EB%A7%88%EC%A7%80%EB%A7%89-%EC%9D%8C%EC%A0%88%EC%9D%B4-%EC%A4%91%EB%B3%B5-%EC%9E%85%EB%A0%A5%EB%90%98%EB%8A%94-%EA%B2%BD%EC%9A%B0-%ED%95%A8%EC%88%98%EA%B0%80-%EB%91%90-%EB%B2%88-%EC%8B%A4%ED%96%89%EB%90%98%EB%8A%94-%EA%B2%BD%EC%9A%B0)
[ 부가 자료 - isComposing 관련 블로그 ](https://velog.io/@jejeje/TIL-onKeyDown-%EB%91%90-%EB%B2%88-%EC%8B%A4%ED%96%89-KeyboardEvent%EC%99%80-isComposing)
[부가 자료 - isComposing에 대한 MDN 문서](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing)