### PR TITLE
채팅 입력 글자수 제한

### DIFF
--- a/client/src/components/atoms/TextArea.tsx
+++ b/client/src/components/atoms/TextArea.tsx
@@ -1,33 +1,34 @@
 import styled from "@emotion/styled";
 import TextareaAutosize from "react-textarea-autosize";
+import { w, h, text, padding } from "@/styles";
 
 export const TextAreaFixedsize = styled.textarea`
-  width: 100%;
-  height: 100%;
-  padding: 10px 15px;
+  ${w("fill")}
+  ${h("fill")}
+  ${padding.vertical(10)}
+  ${padding.horizontal(15)}
   resize: none;
   border: none;
   background: transparent;
-  font-size: 11px;
-  font-weight: 500;
-  color: ${props => props.theme.colors.black};
+  ${text.subtitle}
+  ${text.black}
   ::placeholder {
     font-family: "Noto Sans KR", sans-serif;
-    color: ${props => props.theme.colors.gray300};
+    ${text.gray300}
   }
 `;
 
 export const TextAreaAutosize = styled(TextareaAutosize)`
-  width: 100%;
+  ${w("fill")}
+  max-height: 100%;
   outline: none;
   resize: none;
   border: none;
   background: transparent;
-  font-size: 12px;
-  font-weight: 500;
-  color: ${props => props.theme.colors.black};
+  ${text.body}
+  ${text.black}
   ::placeholder {
     font-family: "Noto Sans KR", sans-serif;
-    color: ${props => props.theme.colors.gray300};
+    ${text.gray300}
   }
 `;

--- a/client/src/components/molecules/ChatInput.tsx
+++ b/client/src/components/molecules/ChatInput.tsx
@@ -40,6 +40,12 @@ const formStyle = css`
   ${round.md}
 `;
 
+const textAreaScrollStyle = css`
+  ${scroll.y}
+  ${scrollBar}
+  overflow-y: scroll;
+`;
+
 interface Props {
   send: (message: string) => void;
 }
@@ -64,7 +70,7 @@ export const ChatInput: React.FC<Props> = ({ send }) => {
       <form css={formStyle}>
         <div css={[row, w("fill"), h("fill")]}>
           <TextAreaAutosize
-            css={[padding.right(10), scroll.y, scrollBar]}
+            css={textAreaScrollStyle}
             onKeyDown={e => {
               if (
                 e.key === "Enter" &&

--- a/client/src/components/molecules/ChatInput.tsx
+++ b/client/src/components/molecules/ChatInput.tsx
@@ -1,20 +1,43 @@
 import React, { useCallback, useMemo } from "react";
-import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 
 import { EmoticonIcon, SendIcon } from "@/assets";
-import { Box, Divider, TextAreaAutosize } from "@/components/atoms";
+import { Divider, TextAreaAutosize } from "@/components/atoms";
 import { useInput } from "@/common/hooks";
+import {
+  w,
+  h,
+  padding,
+  scroll,
+  scrollBar,
+  bg,
+  justify,
+  align,
+  row,
+  gap,
+  border,
+  round,
+} from "@/styles";
 
-const InputForm = styled.form`
-  display: flex;
-  flex-direction: row;
-  gap: 10px;
-  width: 100%;
-  height: 100%;
-  padding: 10px 15px;
-  background-color: ${props => props.theme.colors.white};
-  border: solid 1px ${props => props.theme.colors.gray300};
-  border-radius: 5px;
+const inputBoxStyle = css`
+  ${w("fill")}
+  max-height: 30%;
+  ${padding(10)}
+  ${bg.white100}
+  ${justify.start}
+  ${align.start}
+`;
+
+const formStyle = css`
+  ${row}
+  ${gap(10)}
+  ${w("fill")}
+  ${h("fill")}
+  ${padding.vertical(10)}
+  ${padding.horizontal(15)}
+  ${bg.white}
+  ${border.gray300}
+  ${round.md}
 `;
 
 interface Props {
@@ -24,8 +47,11 @@ interface Props {
 export const ChatInput: React.FC<Props> = ({ send }) => {
   const { input, setValue } = useInput();
 
-  // TODO: disable send button based on `validated`
+  /** TODO: disable send button based on `validated` */
   const validated = useMemo(() => input.value.trim().length > 0, [input.value]);
+
+  /** @constant 클라이언트와 서버에서 사용하는 채팅 메시지의 최대 길이를 지정합니다. */
+  const maxMessageLength = 500;
 
   const sendCurrent = useCallback(() => {
     if (!validated) return;
@@ -33,32 +59,32 @@ export const ChatInput: React.FC<Props> = ({ send }) => {
     setValue("");
   }, [input.value, validated]);
 
-  /** @constant 클라이언트와 서버에서 사용하는 채팅 메시지의 최대 길이를 지정합니다. */
-  const maxMessageLength = 500;
-
   return (
-    <Box w="fill" pad={10} bg="white100">
-      <InputForm>
-        <TextAreaAutosize
-          onKeyDown={e => {
-            if (
-              e.key === "Enter" &&
-              !e.shiftKey &&
-              !e.nativeEvent.isComposing
-            ) {
-              e.preventDefault();
-              sendCurrent();
-            }
-          }}
-          value={input.value}
-          maxLength={maxMessageLength}
-          onChange={input.onChange}
-        />
-        <Divider dir="vertical" />
+    <div css={inputBoxStyle}>
+      <form css={formStyle}>
+        <div css={[row, w("fill"), h("fill")]}>
+          <TextAreaAutosize
+            css={[padding.right(10), scroll.y, scrollBar]}
+            onKeyDown={e => {
+              if (
+                e.key === "Enter" &&
+                !e.shiftKey &&
+                !e.nativeEvent.isComposing
+              ) {
+                e.preventDefault();
+                sendCurrent();
+              }
+            }}
+            value={input.value}
+            maxLength={maxMessageLength}
+            onChange={input.onChange}
+          />
+          <Divider dir="vertical" />
+        </div>
         <EmoticonIcon />
         <SendIcon onClick={sendCurrent} />
         {/* TODO: Replace with button / add hover, actove effect */}
-      </InputForm>
-    </Box>
+      </form>
+    </div>
   );
 };

--- a/client/src/components/molecules/ChatInput.tsx
+++ b/client/src/components/molecules/ChatInput.tsx
@@ -33,6 +33,9 @@ export const ChatInput: React.FC<Props> = ({ send }) => {
     setValue("");
   }, [input.value, validated]);
 
+  /** @constant 클라이언트와 서버에서 사용하는 채팅 메시지의 최대 길이를 지정합니다. */
+  const maxMessageLength = 500;
+
   return (
     <Box w="fill" pad={10} bg="white100">
       <InputForm>
@@ -44,6 +47,7 @@ export const ChatInput: React.FC<Props> = ({ send }) => {
             }
           }}
           value={input.value}
+          maxLength={maxMessageLength}
           onChange={input.onChange}
         />
         <Divider dir="vertical" />

--- a/interface/src/admin/agenda/common.ts
+++ b/interface/src/admin/agenda/common.ts
@@ -32,6 +32,7 @@ export type AdminAgenda = z.infer<typeof AdminAgenda>;
  * some description about admin agenda create schema goes here
  */
 export const AdminAgendaCreate = z.object({
+  // TODO: add max validation
   title: z.string().min(1),
   content: z.string().min(1),
   resolution: z.string().min(1),

--- a/interface/src/admin/agenda/common.ts
+++ b/interface/src/admin/agenda/common.ts
@@ -32,11 +32,10 @@ export type AdminAgenda = z.infer<typeof AdminAgenda>;
  * some description about admin agenda create schema goes here
  */
 export const AdminAgendaCreate = z.object({
-  // TODO: add max validation
-  title: z.string().min(1),
-  content: z.string().min(1),
-  resolution: z.string().min(1),
-  choices: z.array(z.string().min(1)).min(1),
+  title: z.string().min(1).max(255),
+  content: z.string().min(1).max(255),
+  resolution: z.string().min(1).max(255),
+  choices: z.array(z.string().min(1).max(255)).min(1),
   voters: z.object({
     total: z.array(z.number()),
   }),

--- a/interface/src/agenda/template/common.ts
+++ b/interface/src/agenda/template/common.ts
@@ -20,11 +20,11 @@ export type AgendaTemplate = z.infer<typeof AgendaTemplate>;
  * some description about agenda template create schema goes here
  */
 export const AgendaTemplateCreate = z.object({
-  templateName: z.string(),
-  title: z.string(),
-  content: z.string(),
-  resolution: z.string(),
-  choices: z.array(z.string()),
+  templateName: z.string().min(1).max(255),
+  title: z.string().min(1).max(255),
+  content: z.string().min(1).max(255),
+  resolution: z.string().min(1).max(255),
+  choices: z.array(z.string().min(1).max(255)),
 });
 export type AgendaTemplateCreate = z.infer<typeof AgendaTemplateCreate>;
 

--- a/interface/src/chat/client.ts
+++ b/interface/src/chat/client.ts
@@ -7,7 +7,7 @@ import { Message } from "./common";
  * description
  */
 export const Send = z.object({
-  message: z.string().min(1),
+  message: z.string().min(1).max(500),
 });
 export type Send = z.infer<typeof Send>;
 export const SendCb = Message;

--- a/interface/src/chat/common.ts
+++ b/interface/src/chat/common.ts
@@ -2,6 +2,9 @@
 import { z } from "zod";
 import { ChatUser } from "../user";
 
+/** @constant 클라이언트와 서버에서 사용하는 채팅 메시지의 최대 길이를 지정합니다. */
+const maxMessageLength = 500;
+
 /**
  * Message
  * some description about message schema goes here
@@ -10,7 +13,7 @@ export const Message = z.object({
   id: z.number(),
   user: ChatUser,
   type: z.enum(["message", "notice"]),
-  message: z.string().min(1).max(500),
+  message: z.string().min(1).max(maxMessageLength),
   createdAt: z.string().datetime(),
 });
 export type Message = z.infer<typeof Message>;

--- a/interface/src/chat/common.ts
+++ b/interface/src/chat/common.ts
@@ -2,9 +2,6 @@
 import { z } from "zod";
 import { ChatUser } from "../user";
 
-/** @constant 클라이언트와 서버에서 사용하는 채팅 메시지의 최대 길이를 지정합니다. */
-const maxMessageLength = 500;
-
 /**
  * Message
  * some description about message schema goes here
@@ -13,7 +10,7 @@ export const Message = z.object({
   id: z.number(),
   user: ChatUser,
   type: z.enum(["message", "notice"]),
-  message: z.string().min(1).max(maxMessageLength),
+  message: z.string().min(1).max(500),
   createdAt: z.string().datetime(),
 });
 export type Message = z.infer<typeof Message>;

--- a/interface/src/user/tag/common.ts
+++ b/interface/src/user/tag/common.ts
@@ -18,8 +18,8 @@ export type UserTag = z.infer<typeof UserTag>;
  * some description about user tag create schema goes here
  */
 export const UserTagCreate = z.object({
-  title: z.string(),
-  description: z.string(),
+  title: z.string().min(1).max(255),
+  description: z.string().min(1).max(255),
   users: z.array(z.number()),
 });
 export type UserTagCreate = z.infer<typeof UserTagCreate>;


### PR DESCRIPTION
## Summary

It fixes #242, fixes #228
 
1. 아래 이벤트들에 대해 string 길이 검증(min: 1, max: 255)을 적용했습니다. (#242)
	- `chat.send`
	- `admin.agenda.create`
	- `agenda.template.create`
	- `user.tag.create`

2. 채팅 입력 창에 최대 글자 수(500자)와 최대 높이(30%)를 설정하고, 줄이 길어지는 경우 스크롤을 추가했습니다. (#228) 
	- 크로미엄 브라우저에서 보이는 스크롤바
		- <img width="476" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/46402016/96b63dd6-ff3e-4fc5-b910-d254ac2ce176">
	- 파이어폭스 브라우저에서 보이는 스크롤바 (`::-webkit-scrollbar ` css 의사 요소은 크로미엄만 지원)
		- (스크롤바에 커서를 두지 않았을 때)
		   <img width="485" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/46402016/61283a83-cd1b-4936-a2ae-0c19901a9bc2">
		- (스크롤바에 커서를 두었을 때)
		   <img width="467" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/46402016/760a7c3b-9057-4063-87ae-7dd123d20e45">

## Further issues
- #309 : 사용자에게 텍스트 제한이 넘었음을 알려줄 수 있는 인터렉션 요소를 추가합니다.
- #375 : 투표 생성, 투표 템플릿, 유저 태그 생성 모달에서 입력값 검증을 추가합니다.
	

