### PR TITLE
jsx prop spreading 허용

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -85,6 +85,7 @@
         "allowExpressions": true
       }
     ],
+    "react/jsx-props-no-spreading": "off",
     "react/no-unknown-property": [
       "error",
       {


### PR DESCRIPTION
It fixes #366

jsx를 사용할 때 prop을 object spread를 통해 전달하는 것을 허용합니다.

> [참조] jsx prop spreading을 허용하는 이유 (이슈 설명 참조)
> 1. jsx prop spreading을 금지하는 이유
> 	- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md
> 	- 불필요하게 많은 prop이 커스텀 컴포넌트에 전달되는 것을 막고, 특정 컴포넌트가 받을 수 없는 타입의 prop을 전달하는 것을 막음
> 2. 규칙을 비활성화할 수 있는 이유
> 	- prop spreading을 사용하지 않으면 일일이 prop의 속성들을 전달해야 해 불편함
> 	- 커스텀 컴포넌트의 경우 typescript를 사용해 전달되는 prop의 타입을 강제하고 있음 -> 특정 컴포넌트가 받을 수 없는 타입의 prop이 전달되지 않음

저도 규칙 바꾸니 좋은 것 같아요 ㅎㅎ