### PR TITLE
`SelectTemplateBox`가 포커스를 받을 때 강조하기

### DIFF
--- a/client/src/components/atoms/Label.tsx
+++ b/client/src/components/atoms/Label.tsx
@@ -1,27 +1,26 @@
 import styled from "@emotion/styled";
 import { DownArrowIcon } from "@/assets";
+import { w, padding, bg, border, justify, align, round, text } from "@/styles";
 
 export const SelectWrapper = styled.div`
   position: relative;
   display: inline-block;
 `;
 
-export const Select = styled.select<{ w: number; h: number }>`
-  width: ${props => props.w}px;
-  height: ${props => props.h}px;
-  padding: 0 10px;
-  justify-content: space-between;
-  align-items: center;
-  border-radius: 5px;
-  border: 1px solid ${props => props.theme.colors.gray200};
-  background-color: ${props => props.theme.colors.white};
+export const Select = styled.select`
+  ${padding.vertical(0)}
+  ${padding.horizontal(10)}
+  ${justify.between}
+  ${align.center}
+  ${round.md}
+  ${border.gray200}
+  ${bg.white}
 
+  ${text.option1}
+  ${text.gray600}
   font-family: "Noto Sansf KR";
-  font-size: 10px;
   font-style: normal;
-  font-weight: 500;
   line-height: normal;
-  color: ${props => props.theme.colors.gray600};
 
   &:focus {
     outline: none;
@@ -46,27 +45,20 @@ export const PositionedDownArrowIcon = styled(DownArrowIcon)`
   pointer-events: none;
 `;
 
-export const TemplateSelect = styled.select<{ w: number; h: number }>`
-  width: ${props => props.w}px;
-  height: ${props => props.h}px;
-  padding: 0 15px;
-  justify-content: space-between;
-  align-items: center;
-  border-radius: 5px;
-  border: 1px solid ${props => props.theme.colors.gray200};
-  background-color: ${props => props.theme.colors.gray100};
+export const TemplateSelect = styled.select`
+  ${padding.vertical(0)}
+  ${padding.horizontal(15)}
+  ${justify.between}
+  ${align.center}
+  ${round.md}
+  ${border.gray200}
+  ${bg.gray100}
 
-  color: ${props => props.theme.colors.gray300};
-
+  ${text.gray300};
+  ${text.subtitle}
   font-family: "Noto Sansf KR";
-  font-size: 11px;
   font-style: normal;
-  font-weight: 500;
   line-height: normal;
-
-  &:focus {
-    outline: none;
-  }
 
   &:hover {
     cursor: pointer;
@@ -80,21 +72,21 @@ export const TemplateSelect = styled.select<{ w: number; h: number }>`
 `;
 
 export const TagSelect = styled.select`
-  width: 300px;
-  /* height: 38px; */
-  padding: 5px;
-  justify-content: space-between;
-  align-items: center;
-  border-radius: 5px;
-  border: 0px solid ${props => props.theme.colors.gray200};
-  background-color: ${props => props.theme.colors.white};
+  ${w(300)}
+  ${padding(5)}
+  ${justify.between}
+  ${align.center}
+  ${round.md}
+  ${border.gray200}
 
-  color: ${props => props.theme.colors.gray600};
+  border: 0;
+  ${round.md}
+  ${bg.white};
 
+  ${text.gray600};
+  ${text.subtitle}
   font-family: "Noto Sansf KR";
-  font-size: 11px;
   font-style: normal;
-  font-weight: 500;
   line-height: normal;
 
   &:focus {

--- a/client/src/components/atoms/SelectBox.tsx
+++ b/client/src/components/atoms/SelectBox.tsx
@@ -1,4 +1,5 @@
 import React, { type PropsWithChildren } from "react";
+import { w, h } from "@/styles";
 import { PositionedDownArrowIcon, Select, SelectWrapper } from "./Label";
 
 interface SelectBoxProps {
@@ -16,8 +17,7 @@ export const SelectBox: React.FC<SelectBoxProps> = ({
 }) => (
   <SelectWrapper>
     <Select
-      w={width}
-      h={height}
+      css={[w(width), h(height)]}
       onChange={e => onChange(e.target.value)}
       defaultValue=""
     >
@@ -46,8 +46,7 @@ export const SelectText: React.FC<SelectTextProps> = ({
 }) => (
   <SelectWrapper>
     <Select
-      w={width}
-      h={height}
+      css={[w(width), h(height)]}
       onChange={e => onChange(e.target.value)}
       defaultValue=""
     >

--- a/client/src/components/atoms/SelectTemplateBox.tsx
+++ b/client/src/components/atoms/SelectTemplateBox.tsx
@@ -1,4 +1,5 @@
 import React, { type PropsWithChildren } from "react";
+import { w, h } from "@/styles";
 import { useAgendaTemplate } from "@/services/agenda-template";
 import {
   PositionedDownArrowIcon,
@@ -24,8 +25,7 @@ export const SelectTemplateBox: React.FC<Props> = ({
   return (
     <SelectWrapper>
       <TemplateSelect
-        w={width}
-        h={height}
+        css={[w(width), h(height)]}
         onChange={e => onChange(parseInt(e.target.value))}
         defaultValue={0}
       >


### PR DESCRIPTION
## Summary
- 투표 생성, 편집 모달에서 투표 템플릿을 선택하기 위해 사용하는 `SelectTemplateBox` 컴포넌트가 focus를 받아도 모습이 바뀌지 않습니다. focus를 받았을 때 border를 추가하여 focus 됐다는 것을 표시하면 키보드를 통해 템플릿을 설정할 수 있어 접근성이 향상됩니다.
- 머지 전 디자이너님과 논의가 필요해요.
<img width="341" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/46402016/b4a481d9-faaf-4ae6-9bc1-3e28166027f7">
