### PR TITLE
BiseoError 생성 시 serialize 메서드가 존재하지 않음

### DIFF
--- a/packages/api/src/lib/error.ts
+++ b/packages/api/src/lib/error.ts
@@ -1,11 +1,10 @@
 import type { Error as ErrorResponse } from "@biseo/interface/helpers";
 import logger from "@biseo/api/utils/logger";
 
-export class BiseoError {
-  message: string;
-
+export class BiseoError extends Error {
   constructor(message: string) {
-    this.message = message;
+    super(message);
+    Object.setPrototypeOf(this, BiseoError.prototype);
   }
 
   serialize() {

--- a/packages/api/src/lib/error.ts
+++ b/packages/api/src/lib/error.ts
@@ -1,7 +1,13 @@
 import type { Error as ErrorResponse } from "@biseo/interface/helpers";
 import logger from "@biseo/api/utils/logger";
 
-export class BiseoError extends Error {
+export class BiseoError {
+  message: string;
+
+  constructor(message: string) {
+    this.message = message;
+  }
+
   serialize() {
     return { ok: false, message: this.message } as const;
   }


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It fixes #419

biseo-api의 `libs/error.ts`에서 BiseoError 클래스를 Error 클래스를 extend해 사용하고 있는데, TypeScript 2.1부터 Error 클래스를 extend할 수 없다고 합니다(https://github.com/microsoft/TypeScript/issues/12123 이슈 참조).

사실 Error 클래스를 extend할 이유가 없어서(클라이언트에만 전달되는 에러입니다 - 감사해요 @SnowSuno ), BiseoError가 Error를 extend하지 않게 수정하였습니다.

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
