### PR TITLE
feat(profile): complete profile box UI

### DIFF
--- a/packages/web/src/components/molecules/Profile.tsx
+++ b/packages/web/src/components/molecules/Profile.tsx
@@ -21,42 +21,40 @@ type Props = {
 
 export const Profile: React.FC<Props> = ({ displayName, onLogout }) => (
   <div
-    css={[
-      border.gray200,
-      round.md,
-      w(100),
-      column,
-      align.center,
-      gap(4),
-      padding.vertical(5),
-      bg.white,
-      "box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.06)",
-      {
-        position: "absolute",
-        top: "80%",
-        left: "96.2%",
-        transform: "translateX(-100%)",
-        zIndex: 1000,
-      },
-    ]}
+    css={[align.center, { position: "absolute", right: "0px", zIndex: 1000 }]}
   >
+    <div css={[h(5)]} />
     <div
       css={[
+        border.gray200,
         round.md,
         w(100),
-        h(18),
-        padding.horizontal(8),
-        justify.between,
+        column,
         align.center,
+        gap(4),
+        padding.vertical(5),
+        bg.white,
+        "box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.06)",
       ]}
     >
-      <div css={[text.option2, text.gray600, "text-align: center"]}>
-        {displayName}
+      <div
+        css={[
+          round.md,
+          w(100),
+          h(18),
+          padding.horizontal(8),
+          justify.between,
+          align.center,
+        ]}
+      >
+        <div css={[text.option2, text.gray600, "text-align: center"]}>
+          {displayName}
+        </div>
       </div>
+      <Divider />
+      <Button w={90} h={20} padHorizontal={8} onClick={onLogout}>
+        <div css={[text.option2, text.blue600]}>로그아웃</div>
+      </Button>
     </div>
-    <Divider />
-    <Button w={90} h={20} padHorizontal={8} onClick={onLogout}>
-      <div css={[text.option2, text.blue600]}>로그아웃</div>
-    </Button>
   </div>
 );

--- a/packages/web/src/components/organisms/Header.tsx
+++ b/packages/web/src/components/organisms/Header.tsx
@@ -5,17 +5,7 @@ import { LogoIcon } from "@biseo/web/assets";
 import { Box } from "@biseo/web/components/atoms";
 import { HeaderItem, Profile } from "@biseo/web/components/molecules";
 import { useAuth } from "@biseo/web/services/auth";
-import {
-  bg,
-  center,
-  h,
-  w,
-  round,
-  text,
-  justify,
-  align,
-  column,
-} from "@biseo/web/styles";
+import { bg, center, h, w, round, text } from "@biseo/web/styles";
 
 const adminPathList = [
   { name: "유저 모드", path: "" },
@@ -70,7 +60,7 @@ export const Header: React.FC = () => {
           : null}
       </Box>
       <div
-        css={[column, justify.start, align.center, h(32)]}
+        css={[{ position: "relative" }]}
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
       >


### PR DESCRIPTION
# 요약 \*

It closes #347 
p.s. eslint 짱이네용 근데 에러 해결을 조금 미루다가 커밋을 통으로 해버렸어요... 앞으로 나눠서 잘 커밋하겠습니당..

로그아웃 UI 제작
원래 1번째 알파벳이 보이는 버튼을 박스 형태의 div로 바꾸었고, 관련 부분 css 토큰화 형식으로 변경했습니다.
알파벳이 보이는 박스는 relative로, Profile UI는 absolute로 position 설정해서 Profile UI 위치를 박스 위치에 종속시켰습니다.
알파벳이 보이는 박스에 hover한 뒤에 아래 profile UI로 가면 hover 상태가 false가 되는 상황이어서 div로 알파벳이 보이는 박스와 profile UI를 모두 감싼 뒤에 해당 div에 setHover를 사용했습니다
 

# 스크린샷

<img width="112" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/114305937/f2fdbe1b-8c28-4a2b-9566-a6690f1b2d01">

# 이후 Task \*
도와주세요.. 모르겠어요 ㅠㅜㅠ

- [Done] Profile UI 위치 박스에 종속적으로 변경
- [TODO] 박스와 profile 사이의 간격 코드 수정 필요
   위에 있는 알파벳 박스와 profile 창 사이의 gap 설정하면 gap을 지나는 도중에 hover가 false로 바뀌는 상황이라 우선 투명 div로 박스 아래 5px를 투명 div로 만들어서 묶어둔 상황 (뭔가 하드코딩 느낌이라 바꾸고 싶은데 방법을 모르겠어요,,,ㅠ)
