### PR TITLE
fix(agendaSection): scroll display none

### DIFF
--- a/packages/web/src/components/organisms/AgendaSection.tsx
+++ b/packages/web/src/components/organisms/AgendaSection.tsx
@@ -73,7 +73,7 @@ export const AgendaSection: React.FC = () => {
   );
 
   return (
-    <section css={scroll.y}>
+    <section css={[scroll.y, scroll.hidden]}>
       <div css={gridLayout}>
         <AgendaCard.Group agendaStatus="ongoing">
           {getAgendaCards("ongoing")}

--- a/packages/web/src/styles/scroll.ts
+++ b/packages/web/src/styles/scroll.ts
@@ -26,7 +26,14 @@ const applyDirection = (direction: "x" | "y") => css`
   }
 `;
 
+export const hiddenScroll = css`
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
 export const scroll = {
   x: applyDirection("x"),
   y: applyDirection("y"),
+  hidden: hiddenScroll,
 } as const;


### PR DESCRIPTION
# 요약 \*

It closes #417 

종료된 투표 클릭 시에 오른쪽에 알수없는 마진이 생기는 이슈 해결

알 수 없는 마진은 종료된 투표 section이 화면보다 길어지면 생기는 scroll이었음
scroll.ts에서 hidden이라는 새로운 친구를 추가해서 display: none으로 변경해서 해결

# 스크린샷

https://github.com/sparcs-kaist/biseo/assets/114305937/a4406126-c1c0-4a70-b6c3-f9491c11d664



# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
