### PR TITLE
fix: unified Naming

### DIFF
--- a/packages/web/src/components/organisms/AdminAgendaSection.tsx
+++ b/packages/web/src/components/organisms/AdminAgendaSection.tsx
@@ -68,7 +68,7 @@ export const AdminAgendaSection: React.FC = () => {
       </Box>
       <Box dir="column" w={300}>
         <SectionHeader count={ongoingAgendas.length}>
-          진행중인 투표
+          진행 중인 투표
         </SectionHeader>
         {getAgendaCards("ongoing")}
       </Box>

--- a/packages/web/src/components/organisms/OngoingAgendaModal.tsx
+++ b/packages/web/src/components/organisms/OngoingAgendaModal.tsx
@@ -38,7 +38,7 @@ export const OngoingAgendaModal: React.FC = () => {
   };
 
   return (
-    <Modal title="진행 중인 투표">
+    <Modal title=" 중인 투표">
       <Box w={630} justify="space-between" padVertical={15} dir="row">
         <Box w={300} gap={20}>
           <Box gap={10}>

--- a/packages/web/src/components/organisms/OngoingAgendaModal.tsx
+++ b/packages/web/src/components/organisms/OngoingAgendaModal.tsx
@@ -38,7 +38,7 @@ export const OngoingAgendaModal: React.FC = () => {
   };
 
   return (
-    <Modal title=" 중인 투표">
+    <Modal title="진행 중인 투표">
       <Box w={630} justify="space-between" padVertical={15} dir="row">
         <Box w={300} gap={20}>
           <Box gap={10}>

--- a/packages/web/src/constants/phrases.ts
+++ b/packages/web/src/constants/phrases.ts
@@ -2,6 +2,6 @@ import type { AgendaStatus } from "@biseo/interface/agenda";
 
 export const agendaStatusNames: Record<AgendaStatus, string> = {
   preparing: "예정된 투표",
-  ongoing: "진행중인 투표",
+  ongoing: "진행 중인 투표",
   terminated: "종료된 투표",
 } as const;


### PR DESCRIPTION
# 요약 \*

'진행 중인 투표'로 올바른 띄어쓰기로 워딩 통일.

It closes #402 

![image](https://github.com/sparcs-kaist/biseo/assets/105881036/3d8e77ed-f06f-4fc7-8b3b-30dc56a46c92)

# 이후 Task \*

- 없음
