### PR TITLE
fix: vertically center username in profile popup

### DIFF
--- a/packages/web/src/components/molecules/Profile.tsx
+++ b/packages/web/src/components/molecules/Profile.tsx
@@ -43,6 +43,7 @@ export const Profile: React.FC<Props> = ({ displayName, onLogout }) => (
           w(100),
           h(18),
           padding.horizontal(8),
+          padding.vertical(2),
           justify.between,
           align.center,
         ]}


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #468
- 프로필에 나오는 username의 vertical alignment를 center 하였습니다.

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

![image](https://github.com/sparcs-kaist/biseo/assets/140066207/f42da2b5-a0ac-46d8-bbea-0b55475e965c)
![image](https://github.com/sparcs-kaist/biseo/assets/140066207/adb019df-e760-466c-88d4-21cc2b4f4b6c)

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 만약 나중에 프로필의 디자인을 바꿔서 크기를 더 크게 만들게 된다면 그 안에 있는 elements들의 width, height, horizontal and vertical padding 등을 다시 수정하여서 맞추어야 할 것 같습니다.
