### PR TITLE
fix: align 'loading' text to center

### DIFF
--- a/packages/web/src/components/atoms/Text.tsx
+++ b/packages/web/src/components/atoms/Text.tsx
@@ -30,11 +30,21 @@ export const Text = styled.p<{
   variant?: Variants;
   color?: Color;
   position?: "absolute" | "static";
-}>(({ variant = "body", color = "black", theme, position = "static" }) => [
-  css({
-    color: theme.colors[color],
-    position,
-    whiteSpace: "pre-line",
-  }),
-  textStyles[variant],
-]);
+  textAlign?: "center" | "left";
+}>(
+  ({
+    variant = "body",
+    color = "black",
+    theme,
+    position = "static",
+    textAlign = "left",
+  }) => [
+    css({
+      color: theme.colors[color],
+      position,
+      whiteSpace: "pre-line",
+      textAlign,
+    }),
+    textStyles[variant],
+  ],
+);

--- a/packages/web/src/components/organisms/ChatSection.tsx
+++ b/packages/web/src/components/organisms/ChatSection.tsx
@@ -40,7 +40,7 @@ export const ChatSection: React.FC = () => {
           <Message key={message.id} message={message} />
         ))}
         {hasMore && (
-          <Text ref={ref} variant="body" color="gray400">
+          <Text ref={ref} variant="body" color="gray400" textAlign="center">
             로딩 중
           </Text>
         )}


### PR DESCRIPTION
# 요약 \*

It closes #[465](https://github.com/sparcs-kaist/biseo/issues/465)
따로 피그마에 명시된 디자인이 없어서 중앙 정렬을 하였습니다.

고민 하나 했던건 side margin : auto vs text-align : center인데 직관적인 text-align을 사용했습니다.

# 스크린샷

개선 후
![image](https://github.com/sparcs-kaist/biseo/assets/19489734/6acd15d2-b94a-442e-b779-e5d3813745cf)

# 이후 Task \*
