### PR TITLE
fix: adjust '+' line height to one

### DIFF
--- a/packages/web/src/components/molecules/ModalInnerTextBox.tsx
+++ b/packages/web/src/components/molecules/ModalInnerTextBox.tsx
@@ -16,6 +16,8 @@ import "@biseo/web/components/atoms/placeholder.css";
 import { TrashIcon } from "@biseo/web/assets";
 import { css } from "@emotion/react";
 import {
+  colors,
+  text,
   w,
   h,
   padding,
@@ -218,9 +220,7 @@ const TextButton: React.FC<SubmitProps> = ({
       }}
     />
     <Button w={20} h={20} onClick={onSubmit}>
-      <Text color="blue600" variant="boldtitle2" style={{ lineHeight: 1 }}>
-        +
-      </Text>
+      <Text css={[colors.blue600, text.boldtitle2, "line-height: 1"]}>+</Text>
     </Button>
   </BorderedBox>
 );

--- a/packages/web/src/components/molecules/ModalInnerTextBox.tsx
+++ b/packages/web/src/components/molecules/ModalInnerTextBox.tsx
@@ -218,7 +218,7 @@ const TextButton: React.FC<SubmitProps> = ({
       }}
     />
     <Button w={20} h={20} onClick={onSubmit}>
-      <Text color="blue600" variant="boldtitle2">
+      <Text color="blue600" variant="boldtitle2" style={{ lineHeight: 1 }}>
         +
       </Text>
     </Button>


### PR DESCRIPTION
# 요약 \*

It closes [#374](https://github.com/sparcs-kaist/biseo/issues/374)
다른 Text에는 명시적으로 필요하지 않은 필드라고 생각해서 style을 이용해서 적용했습니다

# 스크린샷

수정 전
<img width="776" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/19489734/1def7761-4e66-4b54-8643-181a93f93e23">


수정 후 (24년 03월 27일)
<img width="769" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/19489734/2c672627-2efa-4332-969a-c7c89c159b12">



# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
