### PR TITLE
Feat/display votes in descending chronological order

### DIFF
--- a/packages/api/src/service/admin.agenda.ts
+++ b/packages/api/src/service/admin.agenda.ts
@@ -354,6 +354,9 @@ export const retrieveAll = async (): Promise<schema.AdminAgenda[]> => {
       },
       voters: selectOnlyUser,
     },
+    orderBy: {
+      endAt: "desc",
+    },
   });
 
   const res = agendaFromDB.map(agenda => {

--- a/packages/api/src/service/agenda.ts
+++ b/packages/api/src/service/agenda.ts
@@ -19,6 +19,9 @@ export const retrieveAll = async (
         },
       },
     },
+    orderBy: {
+      endAt: "desc",
+    },
   });
   const res = agendaDbRes.map((agenda): schema.Agenda => {
     const userVotable = agenda.voters.some(v => v.userId === user.id);

--- a/packages/web/src/services/admin-agenda.ts
+++ b/packages/web/src/services/admin-agenda.ts
@@ -77,7 +77,7 @@ export const useAdminAgenda = create<AdminAgendaState>(set => ({
 
 socket.on("admin.agenda.created", adminAgenda => {
   useAdminAgenda.setState(state => ({
-    adminAgendas: [...state.adminAgendas, adminAgenda],
+    adminAgendas: [adminAgenda, ...state.adminAgendas],
   }));
 });
 

--- a/packages/web/src/services/agenda.ts
+++ b/packages/web/src/services/agenda.ts
@@ -54,8 +54,8 @@ socket.on("agenda.voted", ({ id, user, voters }) => {
 socket.on("agenda.terminated", terminatedAgenda => {
   useAgenda.setState(state => ({
     agendas: [
-      ...state.agendas.filter(agenda => agenda.id !== terminatedAgenda.id),
       terminatedAgenda,
+      ...state.agendas.filter(agenda => agenda.id !== terminatedAgenda.id),
     ],
   }));
 });


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #450
백앤드에서 이미 끝나있는 투표를 가장 최근것부터 순서대로 나열하였고, 프론트엔드에서 새롭게 끝난 투표들도 맨 위로 나타나게 바꾸었습니다.

# 스크린샷

![image](https://github.com/sparcs-kaist/biseo/assets/140066207/a746c111-7a6b-471e-8bf5-9056493372d4)

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 만약 현재 진행중인 투표 목록에서도 가장 최근에 열린 투표가 위에 나오게 하고 싶은 일이 생긴다면 같은 방식으로 프론트엔드 코드를 변경하면 될것 같습니다.
