### PR TITLE
feat: recent agendas filtering

### DIFF
--- a/packages/web/src/components/atoms/ToggleSwitch.tsx
+++ b/packages/web/src/components/atoms/ToggleSwitch.tsx
@@ -1,0 +1,52 @@
+import { bg, colors, h, margin, round, row, text, w } from "@biseo/web/styles";
+import React from "react";
+
+interface ToggleSwitchProps {
+  handleToggle: () => void;
+  label: string;
+}
+
+export const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
+  handleToggle,
+  label,
+}) => (
+  <div>
+    <input
+      type="checkbox"
+      id="toggle"
+      onChange={handleToggle}
+      css={[
+        w(0),
+        h(0),
+        `display: none;
+        :checked + label div { background-color: ${colors.blue500}; }
+        :checked + label div span { transform: translateX(10px) }`,
+      ]}
+    />
+    <label htmlFor="toggle" css={[row]}>
+      <div
+        css={[
+          bg.gray300,
+          w(28),
+          h(18),
+          round.xl,
+          `position: relative`,
+          `transition: 0.2s`,
+        ]}
+      >
+        <span
+          css={[
+            w(12),
+            h(12),
+            round.xl,
+            bg.white,
+            margin(3),
+            `position: absolute`,
+            `transition: all 0.2s`,
+          ]}
+        />
+      </div>
+      <span css={[text.subtitle, text.gray600, margin.left(4)]}>{label}</span>
+    </label>
+  </div>
+);

--- a/packages/web/src/components/atoms/ToggleSwitch.tsx
+++ b/packages/web/src/components/atoms/ToggleSwitch.tsx
@@ -23,7 +23,7 @@ export const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
         :checked + label div span { transform: translateX(10px) }`,
       ]}
     />
-    <label htmlFor="toggle" css={[row]}>
+    <label htmlFor="toggle" css={[row, `cursor: pointer`]}>
       <div
         css={[
           bg.gray300,

--- a/packages/web/src/components/molecules/AgendaCard/Group.tsx
+++ b/packages/web/src/components/molecules/AgendaCard/Group.tsx
@@ -7,6 +7,7 @@ import {
   column,
   gap,
   h,
+  justify,
   padding,
   round,
   row,
@@ -15,29 +16,42 @@ import {
 } from "@biseo/web/styles";
 import type { AgendaStatus } from "@biseo/interface/agenda";
 import { agendaStatusNames } from "@biseo/web/constants/phrases";
+import { ToggleSwitch } from "@biseo/web/components/atoms/ToggleSwitch";
 import { EmptyAgendaCard } from "./EmptyAgendaCard";
 
 interface Props extends PropsWithChildren {
   agendaStatus: AgendaStatus;
+  handleRecentOnly?: () => void;
 }
 
-export const Group: React.FC<Props> = ({ agendaStatus, children = null }) => (
+export const Group: React.FC<Props> = ({
+  agendaStatus,
+  handleRecentOnly = () => {},
+  children = null,
+}) => (
   <div>
-    <div css={[row, align.center, h(42), gap(8), padding.horizontal(15)]}>
-      <h2 css={[text.title2, text.black]}>{agendaStatusNames[agendaStatus]}</h2>
-      <div
-        css={[
-          text.body,
-          text.blue600,
-          bg.blue200,
-          w(20),
-          h(20),
-          round.md,
-          center,
-        ]}
-      >
-        {Children.count(children)}
+    <div css={[row, align.center, justify.between, padding.horizontal(15)]}>
+      <div css={[row, align.center, h(42), gap(8)]}>
+        <h2 css={[text.title2, text.black]}>
+          {agendaStatusNames[agendaStatus]}
+        </h2>
+        <div
+          css={[
+            text.body,
+            text.blue600,
+            bg.blue200,
+            w(20),
+            h(20),
+            round.md,
+            center,
+          ]}
+        >
+          {Children.count(children)}
+        </div>
       </div>
+      {agendaStatus === "terminated" && (
+        <ToggleSwitch label="최근 투표만" handleToggle={handleRecentOnly} />
+      )}
     </div>
     {Children.count(children) ? (
       <ul css={[column, gap(15)]}>{children}</ul>

--- a/packages/web/src/components/organisms/AgendaSection.tsx
+++ b/packages/web/src/components/organisms/AgendaSection.tsx
@@ -51,11 +51,8 @@ export const AgendaSection: React.FC = () => {
     (agendaStatus: AgendaStatus) => {
       if (agendaStatus === "preparing") return preparingAgendas;
       if (agendaStatus === "ongoing")
-        return ongoingAgendas.sort((a, b) => {
-          if (a.voters.voted === 0) return -1;
-          if (b.voters.voted === 0) return 1;
-          return 0;
-        });
+        return ongoingAgendas.sort((a, b) => a.voters.voted - b.voters.voted);
+
       if (agendaStatus === "terminated") {
         const recent24Hours = new Date();
         recent24Hours.setDate(new Date().getDate() - 1);

--- a/packages/web/src/components/organisms/AgendaSection.tsx
+++ b/packages/web/src/components/organisms/AgendaSection.tsx
@@ -58,7 +58,7 @@ export const AgendaSection: React.FC = () => {
         recent24Hours.setDate(new Date().getDate() - 1);
         return showRecentAgendasOnly
           ? terminatedAgendas.filter(
-              agenda => new Date(agenda.startAt) > recent24Hours,
+              agenda => new Date(agenda.endAt) > recent24Hours,
             )
           : terminatedAgendas;
       }

--- a/packages/web/src/components/organisms/AgendaSection.tsx
+++ b/packages/web/src/components/organisms/AgendaSection.tsx
@@ -37,7 +37,7 @@ const gridLayout = css`
 `;
 
 export const AgendaSection: React.FC = () => {
-  const [showRecentAgendasOnly] = useState(false);
+  const [showRecentAgendasOnly, setShowRecentAgendasOnly] = useState(false);
 
   const { preparingAgendas, ongoingAgendas, terminatedAgendas } = useAgenda(
     state => ({
@@ -89,7 +89,10 @@ export const AgendaSection: React.FC = () => {
         <AgendaCard.Group agendaStatus="preparing">
           {getAgendaCards("preparing")}
         </AgendaCard.Group>
-        <AgendaCard.Group agendaStatus="terminated">
+        <AgendaCard.Group
+          agendaStatus="terminated"
+          handleRecentOnly={() => setShowRecentAgendasOnly(curr => !curr)}
+        >
           {getAgendaCards("terminated")}
         </AgendaCard.Group>
       </div>


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #475 

종료된 투표 중 24시간 내 **시작된** 투표들만 필터링해주는 토글 스위치를 추가했습니다.
(브랜치명이 recently-started-agendas여야 할 것 같네요 😅 )


# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->

https://github.com/sparcs-kaist/biseo/assets/100757008/a0796c30-1822-4305-96dc-1fcef18a09c4

# 추가 Task
- [x] toggle hovering 시 cursor: pointer 설정

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
