### PR TITLE
feat: display end time on terminated agenda cards instead of start time

### DIFF
--- a/packages/api/src/service/admin.agenda.ts
+++ b/packages/api/src/service/admin.agenda.ts
@@ -28,7 +28,7 @@ const selectAgendaDefaultFields = {
     title: true,
     resolution: true,
     content: true,
-    startAt: true,
+    endAt: true,
   },
 };
 
@@ -95,7 +95,7 @@ export const createAgenda = async ({
       voted: [],
       total: createdVoters.map(voter => voter.user),
     },
-    startAt: "", // startAt is not displayed yet
+    endAt: "", // endAt is not displayed yet
   };
 
   return {
@@ -150,7 +150,7 @@ export const terminateAgenda = async (agendaId: number, user: User) => {
   const {
     voters: updatedVoters,
     choices: updatedChoices,
-    startAt: agendaStartAt,
+    endAt: agendaEndAt,
     ...updatedAgenda
   } = await prisma.agenda.update({
     data: {
@@ -206,7 +206,7 @@ export const terminateAgenda = async (agendaId: number, user: User) => {
       voted: userVoted,
       votable: userVotable,
     },
-    startAt: agendaStartAt?.toISOString() || "", // startAt is not null with terminatedAgenda
+    endAt: agendaEndAt?.toISOString() || "", // startAt is not null with terminatedAgenda
   };
 
   return terminatedAgenda;
@@ -306,7 +306,7 @@ export const updateAgenda = async (agendaUpdate: schema.AdminAgendaUpdate) => {
       voted: [],
       total: voters.map(voter => voter.user),
     },
-    startAt: "",
+    endAt: "",
   };
   return {
     voters: voters.map(voter => `user/${voter.user.username}`),
@@ -389,7 +389,7 @@ export const retrieveAll = async (): Promise<schema.AdminAgenda[]> => {
         total: agenda.voters.map(user => user.user),
         voted,
       },
-      startAt: agenda.startAt?.toISOString() || "",
+      endAt: agenda.endAt?.toISOString() || "",
     };
   });
 

--- a/packages/api/src/service/agenda.ts
+++ b/packages/api/src/service/agenda.ts
@@ -42,7 +42,7 @@ export const retrieveAll = async (
         ),
         total: agenda.voters.length,
       },
-      startAt: agenda.startAt,
+      endAt: agenda.endAt,
     };
 
     if (!agenda.startAt) {
@@ -84,7 +84,7 @@ export const retrieveAll = async (
         name: choice.name,
         count: choice.users.length,
       })),
-      startAt: agenda.startAt.toISOString(),
+      endAt: agenda.endAt.toISOString(),
     };
   });
   if (!res) throw new BiseoError("failed to retrieve agenda");

--- a/packages/interface/src/admin/agenda/common.ts
+++ b/packages/interface/src/admin/agenda/common.ts
@@ -24,7 +24,7 @@ export const AdminAgenda = AgendaBase.omit({
   }),
   status: AdminAgendaStatus,
   choices: z.array(ChoiceWithResult),
-  startAt: z.string(), // currently used only on terminated admin agendas
+  endAt: z.string(), // currently used only on terminated admin agendas
 });
 export type AdminAgenda = z.infer<typeof AdminAgenda>;
 

--- a/packages/interface/src/agenda/common.ts
+++ b/packages/interface/src/agenda/common.ts
@@ -75,7 +75,7 @@ export const TerminatedAgenda = AgendaBase.extend({
     voted: z.number().nullable(), // choiceId | null
   }),
   choices: z.array(ChoiceWithResult),
-  startAt: z.string(),
+  endAt: z.string(),
 });
 export type TerminatedAgenda = z.infer<typeof TerminatedAgenda>;
 

--- a/packages/web/src/components/molecules/AgendaCard/AdminTerminatedAgendaCard.tsx
+++ b/packages/web/src/components/molecules/AgendaCard/AdminTerminatedAgendaCard.tsx
@@ -35,7 +35,7 @@ export const AdminTerminatedAgendaCard: React.FC<Props> = ({ agenda }) => {
             }}
           />
           <p css={[text.subtitle, text.gray400]}>
-            {formatDateSimple(agenda.startAt)}
+            {formatDateSimple(agenda.endAt)}
           </p>
         </div>
         <div css={[column, gap(2)]}>

--- a/packages/web/src/components/molecules/AgendaCard/TerminatedAgendaCard.tsx
+++ b/packages/web/src/components/molecules/AgendaCard/TerminatedAgendaCard.tsx
@@ -46,7 +46,7 @@ export const TerminatedAgendaCard: React.FC<Props> = ({ agenda }) => {
             <div css={[row, justify.between, align.center]}>
               <h1 css={[text.title2, text.black]}>{agenda.title}</h1>
               <p css={[text.subtitle, text.gray400]}>
-                {formatDateSimple(agenda.startAt)}
+                {formatDateSimple(agenda.endAt)}
               </p>
             </div>
             <p css={[text.subtitle, text.gray500]}>{agenda.content}</p>
@@ -89,7 +89,7 @@ export const TerminatedAgendaCard: React.FC<Props> = ({ agenda }) => {
               }}
             />
             <p css={[text.subtitle, text.gray400]}>
-              {formatDateSimple(agenda.startAt)}
+              {formatDateSimple(agenda.endAt)}
             </p>
           </div>
 


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #490 

terminated agenda card에서 보여주던 날짜를 `startAt` 기준에서 `endAt` 기준으로 변경하였습니다. 유저 모드와 투표 관리 모두에 적용됩니다.

# 스크린샷

<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
<img width="518" alt="image" src="https://github.com/sparcs-kaist/biseo/assets/100757008/3f9d9202-74f0-4cc3-bb32-161b8ae5b654">

# 이후 Task \*

<!-- PR 이후 개설할 이슈 목록 -->

- 없음
