### PR TITLE
feat: seperate dev and prod

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -7,10 +7,12 @@ on:
   push:
     branches: 
       - main
+  workflow_dispatch:
+    name: Deploy to Production
 
 jobs:
   publish-docker-image:
-    name: Build and Push
+    name: Build and Push ${{ github.event_name == 'workflow_dispatch' && 'prod' || 'dev' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -50,7 +52,7 @@ jobs:
         with:
           images: ${{ matrix.image }}
           tags: |
-            type=raw,value=latest
+            type=raw,value=${{ github.event_name == 'workflow_dispatch' && 'prod' || 'dev' }}
             type=sha,format=long
 
       - name: Build and push Docker image

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,7 +3,7 @@ name: "biseo"
 services:
   web:
     container_name: biseo-web
-    image: ghcr.io/sparcs-kaist/biseo-web:latest
+    image: ghcr.io/sparcs-kaist/biseo-web:dev
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     restart: always
@@ -18,7 +18,7 @@ services:
 
   api:
     container_name: biseo-api
-    image: ghcr.io/sparcs-kaist/biseo-api:latest
+    image: ghcr.io/sparcs-kaist/biseo-api:dev
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ name: "biseo"
 services:
   web:
     container_name: biseo-web
-    image: ghcr.io/sparcs-kaist/biseo-web:latest
+    image: ghcr.io/sparcs-kaist/biseo-web:prod
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     restart: always
@@ -18,7 +18,7 @@ services:
 
   api:
     container_name: biseo-api
-    image: ghcr.io/sparcs-kaist/biseo-api:latest
+    image: ghcr.io/sparcs-kaist/biseo-api:prod
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     restart: always


### PR DESCRIPTION
# 요약 \*

ghcr image를 기본적으로 dev 태그를 붙여서 push해 dev 서버에서 사용할 수 있게 하고, 이후 별도의 워크플로우를 실행하면 prod 태그로 push해 프로덕션에서 사용할 수 있도록 합니다.