### PR TITLE
feat: add notice page and notice buttons

### DIFF
--- a/packages/api/src/auth/login.ts
+++ b/packages/api/src/auth/login.ts
@@ -7,6 +7,10 @@ import { authenticate } from "./ldap";
 import { gauthenticate } from "./google";
 import { getToken } from "./token";
 
+// import { Client } from "@sparcssso/client/sparcsssov2-node.ts";
+
+// const client = new Client(clientId, secretKey, isBeta = false);
+
 const Login = z.object({
   username: z.string(),
   password: z.string(),
@@ -39,3 +43,44 @@ export const gLoginHandler = async (req: Request, res: Response) => {
 
   return res.json({ token: getToken(user.username) });
 };
+
+// export const ssoLoginHandler = async (req: Request, res: Response) => {
+//   // const {url, stateBefore} = client.getLoginParams(); // 이거 따로 처리?
+//   // res.redirect(url);
+
+//   // const state = res.state;//
+//   // if(stateBefore !== state) {
+//   //   res.status(409).send("TOKEN MISMATCH: session might be hijacked!")
+//   // }
+
+//   // const code = res.code
+
+//   const username="messi";
+
+//   const user =
+//     (await prisma.user.findUnique({ where: { username} })) ||
+//     (await prisma.user.create({ data: { username, displayName: username } }));
+
+//   return res.json({ token: getToken(user.username) });
+// }
+
+// function loginInit(args) {
+//   const { url, state } = client.getLoginParams();
+//   session.state = state; // state 값을 session에 저장합니다.
+//   res.redirect(url); // 사용자를 loginUrl로 redirect 시킵니다.
+// }
+
+// function loginCallback(args) {
+//   const stateBefore = session.state; // session에서 state 값을 얻어옵니다.
+//   const state = args.state; // get param에서 state 값을 얻어옵니다.
+
+//   if (stateBefore !== state) { // 만일 두 state 값이 다르다면
+//     //session이 hijacked 되었을 수 있으므로, 처리를 중단해야 합니다.
+//     throw new Error('TOKEN MISMATCH: session might be hijacked!');
+//   }
+
+//   const code = args.code // get param에서 code 값을 얻어옵니다.
+//   client.getUserInfo(code).then((userData) => {
+//     // 이제 userData를 사용하여 적절한 처리를 하면 됩니다.
+//   }); // dict 형태로 사용자의 데이터를 가져옵니다.
+// }

--- a/packages/api/src/listener/chat.ts
+++ b/packages/api/src/listener/chat.ts
@@ -1,5 +1,10 @@
 import * as schema from "@biseo/interface/chat";
-import { createMessage, retrieve } from "@biseo/api/service/chat";
+import {
+  createMessage,
+  retrieve,
+  modifyMessage,
+  retrieveAdminNotice,
+} from "@biseo/api/service/chat";
 
 import { Router } from "@biseo/api/lib/listener";
 
@@ -11,6 +16,15 @@ router.on("chat.send", schema.Send, async (req, { io, user }) => {
   return message;
 });
 
+router.on("chat.update", schema.Update, async (req, body) => {
+  const message = await modifyMessage(req);
+  body.io.emit("chat.updated", message);
+  return message;
+});
+
 router.on("chat.retrieve", schema.Retrieve, async req => retrieve(req));
+router.on("chat.retrieveAdminNotice", schema.Retrieve, async req =>
+  retrieveAdminNotice(req),
+);
 
 export { router as chatRouter };

--- a/packages/api/src/service/chat.ts
+++ b/packages/api/src/service/chat.ts
@@ -7,6 +7,12 @@ export const createMessage = async (
   { message, type }: schema.Send,
   user: User,
 ): Promise<schema.Message> => {
+  const anonUser: User = {
+    id: 0,
+    isAdmin: false,
+    username: "익명",
+    displayName: "익명",
+  };
   const sendQuery: Prisma.ChatCreateInput = {
     user: { connect: user },
     type,
@@ -30,16 +36,42 @@ export const createMessage = async (
     },
   });
 
-  if (type === "anonymous") {
-    createdMessage.user.id = 0;
-    createdMessage.user.displayName = "익명";
-  }
+  if (type === "anonymous") createdMessage.user = anonUser;
 
   console.log(createdMessage);
 
   return {
     ...createdMessage,
     createdAt: createdAt.toISOString(),
+  };
+};
+
+export const modifyMessage = async ({
+  id,
+  type,
+}: schema.Update): Promise<schema.Message> => {
+  const updated = await prisma.chat.update({
+    where: { id },
+    data: { type },
+    include: {
+      user: {
+        select: {
+          id: true,
+          displayName: true,
+        },
+      },
+    },
+  });
+
+  return {
+    id: updated.id,
+    message: updated.message,
+    type: updated.type,
+    createdAt: updated.createdAt.toISOString(),
+    user: {
+      id: updated.user.id,
+      displayName: updated.user.displayName,
+    },
   };
 };
 
@@ -77,6 +109,12 @@ export const retrieve = async ({
   lastChatId,
   limit,
 }: schema.Retrieve): Promise<schema.Message[]> => {
+  const anonUser: User = {
+    id: 0,
+    isAdmin: false,
+    username: "익명",
+    displayName: "익명",
+  };
   const messages = await prisma.chat.findMany({
     orderBy: {
       id: "desc",
@@ -100,10 +138,49 @@ export const retrieve = async ({
 
   return messages.map(({ createdAt, ...message }) => {
     const displayMessage = message;
-    if (message.type === "anonymous") {
-      displayMessage.user.id = 0;
-      displayMessage.user.displayName = "익명";
-    }
+    if (message.type === "anonymous") displayMessage.user = anonUser;
+    return {
+      ...displayMessage,
+      createdAt: createdAt.toISOString(),
+    };
+  });
+};
+
+export const retrieveAdminNotice = async ({
+  lastChatId,
+  limit,
+}: schema.Retrieve): Promise<schema.Message[]> => {
+  const anonUser: User = {
+    id: 0,
+    isAdmin: false,
+    username: "익명",
+    displayName: "익명",
+  };
+  const messages = await prisma.chat.findMany({
+    orderBy: {
+      id: "desc",
+    },
+    where: {
+      type: "adminnotice", // ─ always 필터
+      ...(lastChatId != null
+        ? { id: { lt: lastChatId } } // ─ lastChatId 있을 때만 추가 필터
+        : {}),
+    },
+    take: limit,
+    select: {
+      id: true,
+      user: true,
+      type: true,
+      message: true,
+      createdAt: true,
+    },
+  });
+
+  // console.log(messages);
+
+  return messages.map(({ createdAt, ...message }) => {
+    const displayMessage = message;
+    if (message.type === "anonymous") displayMessage.user = anonUser;
     return {
       ...displayMessage,
       createdAt: createdAt.toISOString(),

--- a/packages/interface/src/chat/client.ts
+++ b/packages/interface/src/chat/client.ts
@@ -15,6 +15,19 @@ export const SendCb = Message;
 export type SendCb = z.infer<typeof SendCb>;
 
 /**
+ * Modify(or Update)
+ * description
+ */
+
+export const Update = z.object({
+  id: z.number(),
+  type: MessageType,
+});
+export type Update = z.infer<typeof Update>;
+export const UpdateCb = Message;
+export type UpdateCb = z.infer<typeof UpdateCb>;
+
+/**
  * Retrieve
  * description
  */

--- a/packages/interface/src/events.ts
+++ b/packages/interface/src/events.ts
@@ -9,10 +9,14 @@ import type * as chat from "./chat";
 import type * as user from "./user";
 import type * as userTag from "./user/tag";
 
+// TODO notice.retrieve, admin.chat.send/update 집어넣기
+
 export type ClientToServerEvents = Events<{
   chat: {
     send: Ev<chat.Send, chat.SendCb>;
+    update: Ev<chat.Update, chat.UpdateCb>;
     retrieve: Ev<chat.Retrieve, chat.RetrieveCb>;
+    retrieveAdminNotice: Ev<chat.Retrieve, chat.RetrieveCb>;
   };
   agenda: {
     retrieveAll: Ev<agenda.RetrieveAll, agenda.RetrieveAllCb>;
@@ -54,6 +58,7 @@ export type ServerToClientEvents = Events<{
   init: Ev<init.Init>;
   chat: {
     received: Ev<chat.Received>;
+    updated: Ev<chat.Received>;
   };
   agenda: {
     created: Ev<agenda.Created>;

--- a/packages/web/src/components/molecules/ChatHeader.tsx
+++ b/packages/web/src/components/molecules/ChatHeader.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import React from "react";
 import { Text } from "@biseo/web/components/atoms";
 import { css } from "@emotion/react";
@@ -11,10 +12,12 @@ import {
   row,
   w,
 } from "@biseo/web/styles";
-import { Megaphone } from "lucide-react";
+import { Megaphone, ArrowLeft } from "lucide-react";
 
 interface Props {
   title: string;
+  onToggle?: () => void;
+  isNotice?: boolean;
 }
 
 const containerStyle = css`
@@ -44,11 +47,21 @@ const iconStyle = css`
   }
 `;
 
-export const ChatHeader: React.FC<Props> = ({ title }) => (
+// eslint-disable-next-line react/require-default-props
+export const ChatHeader: React.FC<Props> = ({
+  title,
+  onToggle,
+  isNotice = false,
+}) => (
   <div css={containerStyle}>
     <Text variant="title2">{title}</Text>
-    <div css={iconStyle}>
-      <Megaphone size={20} color={colors.gray400} />
+    {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+    <div css={iconStyle} onClick={onToggle}>
+      {isNotice ? (
+        <ArrowLeft size={20} color={colors.gray600} />
+      ) : (
+        <Megaphone size={20} color={colors.gray600} />
+      )}
     </div>
   </div>
 );

--- a/packages/web/src/components/molecules/ChatInput.tsx
+++ b/packages/web/src/components/molecules/ChatInput.tsx
@@ -134,7 +134,7 @@ export const ChatInput: React.FC<Props> = ({ send }) => {
                     type === "adminnotice" ? colors.blue600 : colors.gray300
                   }
                   style={{ cursor: "pointer" }}
-                  // onClick={() => onTypeChange("adminnotice")}
+                  onClick={() => onTypeChange("adminnotice")}
                 />
               </BubbleItem>
             )}

--- a/packages/web/src/services/chat/hooks.ts
+++ b/packages/web/src/services/chat/hooks.ts
@@ -9,15 +9,27 @@ import { byReverseCreatedTime } from "./common";
 export const useChat = () => {
   const { userInfo } = useAuth();
 
-  const { messages, sendWithUser, loadMore, loading, hasMore } = useChatStore(
-    state => ({
-      messages: [...state.messages.values()].sort(byReverseCreatedTime),
-      loading: state.loading,
-      hasMore: state.hasMore,
-      sendWithUser: state.send,
-      loadMore: state.load,
-    }),
-  );
+  const {
+    messages,
+    notices,
+    sendWithUser,
+    loadMore,
+    loadNotices,
+    loading,
+    hasMore,
+    hasMoreNotices,
+    updateMessageType,
+  } = useChatStore(state => ({
+    messages: [...state.messages.values()].sort(byReverseCreatedTime),
+    notices: [...state.notices.values()].sort(byReverseCreatedTime),
+    loading: state.loading,
+    hasMore: state.hasMore,
+    hasMoreNotices: state.hasMoreNotices,
+    sendWithUser: state.send,
+    loadMore: state.load,
+    loadNotices: state.loadNotices,
+    updateMessageType: state.updateMessageType,
+  }));
 
   const sendMessage = useCallback(
     async (message: string, type: MessageType) =>
@@ -25,5 +37,21 @@ export const useChat = () => {
     [userInfo, sendWithUser],
   );
 
-  return { messages, loading, hasMore, sendMessage, loadMore };
+  const fetchLatestNotice = useCallback(
+    () => Promise.resolve(notices[0] ?? null),
+    [notices],
+  );
+
+  return {
+    messages,
+    notices,
+    loading,
+    hasMore,
+    hasMoreNotices,
+    sendMessage,
+    loadMore,
+    loadNotices,
+    updateMessageType,
+    fetchLatestNotice,
+  };
 };

--- a/packages/web/src/services/chat/listener.ts
+++ b/packages/web/src/services/chat/listener.ts
@@ -3,4 +3,18 @@ import { useChatStore } from "./store";
 
 socket.on("chat.received", message => {
   useChatStore.getState().append(message);
+  if (message.type === "adminnotice") {
+    useChatStore.getState().appendNotice(message);
+  }
+});
+
+socket.on("chat.updated", message => {
+  const store = useChatStore.getState();
+  store.append(message);
+
+  if (message.type === "adminnotice") {
+    store.appendNotice(message);
+  } else {
+    store.removeNotice(message.id);
+  }
 });


### PR DESCRIPTION
# 요약 \*

<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #503

# 스크린샷
우측 상단의 버튼을 누르면 공지 창과 스레드 창을 전환할 수 있습니다. 

<img width="464" alt="image" src="https://github.com/user-attachments/assets/716feda9-5452-4c64-ae53-eb7992e03d4a" />
<img width="466" alt="image" src="https://github.com/user-attachments/assets/7978feba-86fa-4131-ade0-e519b36cafd1" />


# 이후 Task \*

- [ ] 채팅 최상단에 최근 공지 1개 보여주기 기능 추가하기
- [ ] 버튼이 아닌 스레드 / 공지 텍스트를 통해 창 전환하기
- [ ] 각 채팅의 "공지로 설정" 버튼 UI 개선
